### PR TITLE
IEBH-475: Upgrade dependencies and fix failing tests

### DIFF
--- a/.github/workflows/development-tests.yaml
+++ b/.github/workflows/development-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         run: uv run pytest tests -vvv --durations=5 --video=retain-on-failure --base-url=https://dev.hdc.ebrains.eu
 
       - name: Upload videos with failures
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: videos

--- a/.github/workflows/development-tests.yaml
+++ b/.github/workflows/development-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           E2E_TESTING_ADMIN_PASSWORD: ${{ secrets.E2E_TESTING_ADMIN_PASSWORD }}
           E2E_TESTING_COLLABORATOR_PASSWORD: ${{ secrets.E2E_TESTING_COLLABORATOR_PASSWORD }}
           E2E_TESTING_PILOTCLI_VERSION_TAG: ${{ vars.E2E_TESTING_PILOTCLI_VERSION_TAG }}
-        run: uv run pytest tests -vvv --durations=5 --video=retain-on-failure --base-url=https://dev.hdc.ebrains.eu
+        run: uv run pytest tests -vvv --slowmo 500 --durations=5 --video=retain-on-failure --base-url=https://dev.hdc.ebrains.eu
 
       - name: Upload videos with failures
         uses: actions/upload-artifact@v6

--- a/.github/workflows/production-tests.yaml
+++ b/.github/workflows/production-tests.yaml
@@ -43,7 +43,7 @@ jobs:
         run: uv run pytest tests -vvv --durations=5 --exitfirst --video=retain-on-failure --base-url=https://hdc.ebrains.eu
 
       - name: Upload videos with failures
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: videos

--- a/.github/workflows/production-tests.yaml
+++ b/.github/workflows/production-tests.yaml
@@ -40,7 +40,7 @@ jobs:
           E2E_TESTING_ADMIN_PASSWORD: ${{ secrets.E2E_TESTING_ADMIN_PASSWORD }}
           E2E_TESTING_COLLABORATOR_PASSWORD: ${{ secrets.E2E_TESTING_COLLABORATOR_PASSWORD }}
           E2E_TESTING_PILOTCLI_VERSION_TAG: ${{ vars.E2E_TESTING_PILOTCLI_VERSION_TAG }}
-        run: uv run pytest tests -vvv --durations=5 --exitfirst --video=retain-on-failure --base-url=https://hdc.ebrains.eu
+        run: uv run pytest tests -vvv --slowmo 500 --durations=5 --exitfirst --video=retain-on-failure --base-url=https://hdc.ebrains.eu
 
       - name: Upload videos with failures
         uses: actions/upload-artifact@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e2e-tests"
-version = "0.2.7"
+version = "0.2.8"
 description = "Pilot-HDC end-to-end tests."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
@@ -10,8 +10,8 @@ dependencies = [
     "pytest>=8.4.2",
     "pytest-playwright>=0.7.1",
     "pytest-random-order>=1.2.0",
-    "requests>=2.32.5",
-    "testcontainers>=4.13.2",
+    "requests>=2.33.1",
+    "testcontainers>=4.14.2",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/fixtures/dataset_explorer.py
+++ b/tests/fixtures/dataset_explorer.py
@@ -7,6 +7,7 @@
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
+from http import HTTPStatus
 from typing import Annotated
 from typing import Self
 
@@ -86,7 +87,9 @@ class DatasetExplorer:
             authors_input.press('Enter')
             authors_input.press('Escape')
 
-        with self.page.expect_response(lambda r: r.url.endswith('v1/datasets/') and r.request.method == 'POST'):
+        with self.page.expect_response(
+            lambda r: r.url.endswith('v1/datasets/') and r.request.method == 'POST' and r.status == HTTPStatus.OK
+        ):
             self.page.get_by_role('button', name='Create').click()
 
         return self

--- a/tests/fixtures/file_explorer.py
+++ b/tests/fixtures/file_explorer.py
@@ -248,11 +248,11 @@ class FileExplorer:
     def maximize_page_size(self) -> Self:
         active_tab = self.page.locator('div.ant-tabs-tabpane-active')
         if active_tab.locator('li.ant-pagination-item').count() > 1:
-            pagination = active_tab.locator('li.ant-pagination-options div.ant-select')
-            pagination.click()
+            active_tab.locator('li.ant-pagination-options div.ant-select').click()
             with self.wait_until_refreshed():
-                pagination.press('ArrowUp')
-                pagination.press('Enter')
+                active_tab.locator('div.ant-select-dropdown').wait_for(state='visible')
+                self.page.keyboard.press('ArrowUp')
+                self.page.keyboard.press('Enter')
         return self
 
     def navigate_to(self, folder_path: Path) -> Self:

--- a/tests/fixtures/file_explorer.py
+++ b/tests/fixtures/file_explorer.py
@@ -218,6 +218,11 @@ class FileExplorer:
 
         return self
 
+    def copy_to_core_and_wait_for_completion(self, names: list[str], core_folder_path: Path) -> Self:
+        self.copy_to_core(names, core_folder_path)
+        self.wait_for_copy_to_core_completion(names)
+        return self
+
     def add_to_dataset(self, names: list[str], dataset_code: str) -> Self:
         for name in names:
             self.locate_row(name).get_by_role('checkbox').check()
@@ -287,7 +292,7 @@ class FileExplorer:
     ) -> Self:
         self.create_folders_in_greenroom_and_core(folder_path)
         self.upload_files_and_wait_until_uploaded_and_available(files)
-        self.copy_to_core(files.names, folder_path).switch_to_core()
+        self.copy_to_core_and_wait_for_completion(files.names, folder_path).switch_to_core()
         self.add_to_dataset(files.names, dataset_code)
         return self
 

--- a/tests/fixtures/file_explorer.py
+++ b/tests/fixtures/file_explorer.py
@@ -248,9 +248,11 @@ class FileExplorer:
     def maximize_page_size(self) -> Self:
         active_tab = self.page.locator('div.ant-tabs-tabpane-active')
         if active_tab.locator('li.ant-pagination-item').count() > 1:
-            active_tab.locator('li.ant-pagination-options div.ant-select').click()
+            pagination = active_tab.locator('li.ant-pagination-options div.ant-select')
+            pagination.click()
             with self.wait_until_refreshed():
-                active_tab.locator('div.ant-select-dropdown div.ant-select-item').last.click()
+                pagination.press('ArrowUp')
+                pagination.press('Enter')
         return self
 
     def navigate_to(self, folder_path: Path) -> Self:

--- a/tests/fixtures/file_explorer.py
+++ b/tests/fixtures/file_explorer.py
@@ -249,8 +249,8 @@ class FileExplorer:
         active_tab = self.page.locator('div.ant-tabs-tabpane-active')
         if active_tab.locator('li.ant-pagination-item').count() > 1:
             active_tab.locator('li.ant-pagination-options div.ant-select').click()
+            active_tab.locator('div.ant-select-dropdown').wait_for(state='visible')
             with self.wait_until_refreshed():
-                active_tab.locator('div.ant-select-dropdown').wait_for(state='visible')
                 self.page.keyboard.press('ArrowUp')
                 self.page.keyboard.press('Enter')
         return self

--- a/tests/fixtures/file_explorer.py
+++ b/tests/fixtures/file_explorer.py
@@ -12,6 +12,7 @@ import zipfile
 from collections.abc import Callable
 from collections.abc import Generator
 from contextlib import contextmanager
+from http import HTTPStatus
 from pathlib import Path
 from typing import IO
 from typing import Annotated
@@ -204,7 +205,8 @@ class FileExplorer:
         dialog = self.page.get_by_role('dialog')
         dialog.get_by_role('button', name='Select Destination').click()
 
-        dialog.locator('div.ant-tree-treenode').filter(has=self.page.get_by_role('img', name='user')).click()
+        with self.wait_until_file_list_loaded():
+            dialog.locator('div.ant-tree-treenode').filter(has=self.page.get_by_role('img', name='user')).click()
         self.select_path_in_dialog_tree(dialog, core_folder_path)
         dialog.get_by_role('button', name='Select').click()
 
@@ -465,6 +467,11 @@ class FileExplorer:
             yield
 
     @contextmanager
+    def wait_until_file_list_loaded(self) -> Generator[None]:
+        with self.page.expect_response(lambda r: 'v1/files/meta?' in r.url and r.status == HTTPStatus.OK):
+            yield
+
+    @contextmanager
     def wait_until_uploaded_and_available(self, names: list[str]) -> Generator[None]:
         with self.wait_until_uploaded(names):
             yield
@@ -488,7 +495,8 @@ class FileExplorer:
                     folders[folder_name] = folder
 
             try:
-                folders[path_parts[0]].click()
+                with self.wait_until_file_list_loaded():
+                    folders[path_parts[0]].click()
                 path_parts.pop(0)
                 start_level += 1
             except KeyError:

--- a/tests/fixtures/pilotcli.py
+++ b/tests/fixtures/pilotcli.py
@@ -29,7 +29,7 @@ class Container(DockerContainer):
         stdout, _ = self.get_logs()
         return stdout.decode()
 
-    def wait_until_stopped(self, *, timeout: int = 10000) -> str:
+    def wait_until_stopped(self, *, timeout: int = 30000) -> str:
         wrapped = self.get_wrapped_container()
 
         start_time = tm.monotonic()
@@ -41,7 +41,7 @@ class Container(DockerContainer):
 
         raise PlaywrightTimeoutError(f'Container did not stop within {timeout} milliseconds.')
 
-    def wait_for_logs(self, text: str, timeout: int = 10000) -> str:
+    def wait_for_logs(self, text: str, timeout: int = 30000) -> str:
         wait_for_logs(self, LogMessageWaitStrategy(text), timeout=timeout / 1000)
         return self.get_stdout()
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -78,7 +78,7 @@ def test_add_folder_with_files_to_dataset(
     with admin_file_explorer.wait_until_uploaded([file_1.name, file_2.name]):
         admin_file_explorer.upload_folder(folder_path)
 
-    admin_file_explorer.copy_to_core([folder_name], full_working_path).switch_to_core()
+    admin_file_explorer.copy_to_core_and_wait_for_completion([folder_name], full_working_path).switch_to_core()
     admin_file_explorer.add_to_dataset([folder_name], dataset.code)
     admin_dataset_explorer.open(dataset.code).wait_for_import_completion([folder_name], timeout=4 * 60000)
 

--- a/tests/test_file_explorer.py
+++ b/tests/test_file_explorer.py
@@ -130,7 +130,7 @@ def test_file_with_tags_copy_to_core_zone(admin_file_explorer: FileExplorer, wor
     file = File.generate(tags_number=3)
     admin_file_explorer.upload_file_and_wait_until_uploaded_and_available(file)
 
-    admin_file_explorer.copy_to_core([file.name], full_working_path).switch_to_core()
+    admin_file_explorer.copy_to_core_and_wait_for_completion([file.name], full_working_path).switch_to_core()
 
     received_tags = admin_file_explorer.get_file_tags(file.name)
 

--- a/tests/test_pilotcli.py
+++ b/tests/test_pilotcli.py
@@ -43,8 +43,7 @@ def test_file_is_successfully_downloaded_from_core_zone(
     file = File.generate()
     admin_file_explorer.upload_file_and_wait_until_uploaded_and_available(file)
 
-    admin_file_explorer.copy_to_core([file.name], full_working_path)
-    admin_file_explorer.wait_for_copy_to_core_completion([file.name])
+    admin_file_explorer.copy_to_core_and_wait_for_completion([file.name], full_working_path)
 
     admin_pilotcli.login(admin_file_explorer.page)
 

--- a/uv.lock
+++ b/uv.lock
@@ -387,11 +387,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "e2e-tests"
-version = "0.2.7"
+version = "0.2.8"
 source = { virtual = "." }
 dependencies = [
     { name = "mimesis" },
@@ -86,8 +86,8 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-playwright", specifier = ">=0.7.1" },
     { name = "pytest-random-order", specifier = ">=1.2.0" },
-    { name = "requests", specifier = ">=2.32.5" },
-    { name = "testcontainers", specifier = ">=4.13.2" },
+    { name = "requests", specifier = ">=2.33.1" },
+    { name = "testcontainers", specifier = ">=4.14.2" },
 ]
 
 [[package]]
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -334,14 +334,14 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
 name = "testcontainers"
-version = "4.13.2"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docker" },
@@ -350,9 +350,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/51/edac83edab339d8b4dce9a7b659163afb1ea7e011bfed1d5573d495a4485/testcontainers-4.13.2.tar.gz", hash = "sha256:2315f1e21b059427a9d11e8921f85fef322fbe0d50749bcca4eaa11271708ba4", size = 78692, upload-time = "2025-10-07T21:53:07.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/5e/73aa94770f1df0595364aed526f31d54440db5492911e2857318ed326e51/testcontainers-4.13.2-py3-none-any.whl", hash = "sha256:0209baf8f4274b568cde95bef2cadf7b1d33b375321f793790462e235cd684ee", size = 124771, upload-time = "2025-10-07T21:53:05.937Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Upgrade actions to remove Node.js 20 deprecation warning.
- Upgrade dependencies.
- Add extra wait to prevent the tests from failing.
- Wait for copy to core zone task to finish everywhere.
- Refactor pagination handling.